### PR TITLE
Manipulate local vertex position of shape

### DIFF
--- a/primitives.py
+++ b/primitives.py
@@ -1,6 +1,6 @@
 import pyglet
 from pyglet import window, app, shapes
-from pyglet.math import Mat4, Vec3
+from pyglet.math import Mat4, Vec3, Vec4
 import math
 from pyglet.gl import *
 
@@ -10,20 +10,19 @@ class CustomGroup(pyglet.graphics.Group):
     '''
     To draw multiple 3D shapes in Pyglet, you should make a group for an object.
     '''
-    def __init__(self, id, shader_program:shader.ShaderProgram,
-                 translate_mat: Mat4, rotation_vec:Vec3, order=0):
+    def __init__(self, shader_program:shader.ShaderProgram,
+                 transform_mat: Mat4, order):
         super().__init__(order)
-        self.id = id
         self.program = shader_program
-        self.translate_mat = translate_mat
-        self.rotation_vec = rotation_vec
+        self.transform_mat = transform_mat
         self.angle = 0
+        self.rotate_axis = Vec3(0,1,0)
         self.program.use()
 
     def set_state(self):
         self.program.use()
-        rotate_mat_x = Mat4.from_rotation(angle = self.angle, vector = self.rotation_vec)
-        model = self.translate_mat @ rotate_mat_x
+        rotate_mat_x = Mat4.from_rotation(angle = self.angle, vector = self.rotate_axis)
+        model = self.transform_mat @ rotate_mat_x
         self.program['model'] = model
 
     def unset_state(self):
@@ -31,11 +30,11 @@ class CustomGroup(pyglet.graphics.Group):
 
     def __eq__(self, other):
         return (self.__class__ is other.__class__ and
-                self.id == other.id and
+                self.order == other.order and
                 self.parent == other.parent)
     
     def __hash__(self):
-        return hash((self.id)) 
+        return hash((self.order)) 
     
 
 class Cube:

--- a/primitives.py
+++ b/primitives.py
@@ -15,14 +15,11 @@ class CustomGroup(pyglet.graphics.Group):
         super().__init__(order)
         self.program = shader_program
         self.transform_mat = transform_mat
-        self.angle = 0
-        self.rotate_axis = Vec3(0,1,0)
         self.program.use()
 
     def set_state(self):
         self.program.use()
-        rotate_mat_x = Mat4.from_rotation(angle = self.angle, vector = self.rotate_axis)
-        model = self.transform_mat @ rotate_mat_x
+        model = self.transform_mat
         self.program['model'] = model
 
     def unset_state(self):

--- a/primitives.py
+++ b/primitives.py
@@ -10,20 +10,27 @@ class CustomGroup(pyglet.graphics.Group):
     '''
     To draw multiple 3D shapes in Pyglet, you should make a group for an object.
     '''
-    def __init__(self, shader_program:shader.ShaderProgram,
-                 transform_mat: Mat4, order):
+    def __init__(self, transform_mat: Mat4, order):
         super().__init__(order)
-        self.program = shader_program
+
+        '''
+        Create shader program for each shape
+        '''
+        self.shader_program = shader.create_program(
+            shader.vertex_source_default, shader.fragment_source_default
+        )
+
         self.transform_mat = transform_mat
-        self.program.use()
+        self.indexed_vertices_list = None
+        self.shader_program.use()
 
     def set_state(self):
-        self.program.use()
+        self.shader_program.use()
         model = self.transform_mat
-        self.program['model'] = model
+        self.shader_program['model'] = model
 
     def unset_state(self):
-        self.program.stop()
+        self.shader_program.stop()
 
     def __eq__(self, other):
         return (self.__class__ is other.__class__ and

--- a/render.py
+++ b/render.py
@@ -68,8 +68,10 @@ class RenderWindow(pyglet.window.Window):
             shapes created later rotate faster while positions are not changed.
             '''
             if self.animate:
-                shape.rotate_axis = Vec3(0,0,1)
-                shape.angle += (i+1)*dt
+                rotate_angle = dt
+                rotate_axis = Vec3(0,0,1)
+                rotate_mat_x = Mat4.from_rotation(angle = rotate_angle, vector = rotate_axis)
+                shape.transform_mat @= rotate_mat_x
             '''
             Update view and projection matrix. There exist only one view and projection matrix 
             in the program, so we just assign the same matrices for all the shapes
@@ -104,4 +106,5 @@ class RenderWindow(pyglet.window.Window):
     def run(self):
         pyglet.clock.schedule_interval(self.update, 1/60)
         pyglet.app.run()
+
     

--- a/render.py
+++ b/render.py
@@ -35,6 +35,7 @@ class RenderWindow(pyglet.window.Window):
         self.proj_mat = None
 
         self.shapes = []
+        self.shader_program = []
         self.setup()
 
         self.animate = False
@@ -70,13 +71,13 @@ class RenderWindow(pyglet.window.Window):
             if self.animate:
                 rotate_angle = dt
                 rotate_axis = Vec3(0,0,1)
-                rotate_mat_x = Mat4.from_rotation(angle = rotate_angle, vector = rotate_axis)
+                rotate_mat_x = Mat4.from_rotation(angle = rotate_angle, vector = rotate_axis)                
                 shape.transform_mat @= rotate_mat_x
             '''
             Update view and projection matrix. There exist only one view and projection matrix 
             in the program, so we just assign the same matrices for all the shapes
             '''
-            shape.program['view_proj'] = view_proj
+            shape.shader_program['view_proj'] = view_proj
 
     def on_resize(self, width, height):
         glViewport(0, 0, *self.get_framebuffer_size())
@@ -85,22 +86,17 @@ class RenderWindow(pyglet.window.Window):
         return pyglet.event.EVENT_HANDLED
 
     def add_shape(self, transform, vertice, indice, color):
-        '''
-        Create shader program for each shape
-        '''
-        shader_program = shader.create_program(
-            shader.vertex_source_default, shader.fragment_source_default
-        )
+        
         '''
         Assign a group for each shape
         '''
-        shape = CustomGroup(shader_program, transform, len(self.shapes))
-        shader_program.vertex_list_indexed(len(vertice)//3, GL_TRIANGLES,
+        shape = CustomGroup(transform, len(self.shapes))
+        shape.indexed_vertices_list = shape.shader_program.vertex_list_indexed(len(vertice)//3, GL_TRIANGLES,
                         batch = self.batch,
                         group = shape,
                         indices = indice,
                         vertices = ('f', vertice),
-                        colors = ('Bn', color)) 
+                        colors = ('Bn', color))
         self.shapes.append(shape)
          
     def run(self):

--- a/render.py
+++ b/render.py
@@ -68,6 +68,7 @@ class RenderWindow(pyglet.window.Window):
             shapes created later rotate faster while positions are not changed.
             '''
             if self.animate:
+                shape.rotate_axis = Vec3(0,0,1)
                 shape.angle += (i+1)*dt
             '''
             Update view and projection matrix. There exist only one view and projection matrix 
@@ -81,7 +82,7 @@ class RenderWindow(pyglet.window.Window):
             aspect = width/height, z_near=self.z_near, z_far=self.z_far, fov = self.fov)
         return pyglet.event.EVENT_HANDLED
 
-    def add_shape(self, pos, vertice, indice, color):
+    def add_shape(self, transform, vertice, indice, color):
         '''
         Create shader program for each shape
         '''
@@ -91,7 +92,7 @@ class RenderWindow(pyglet.window.Window):
         '''
         Assign a group for each shape
         '''
-        shape = CustomGroup(len(self.shapes), shader_program, pos, Vec3(0,0,1))
+        shape = CustomGroup(shader_program, transform, len(self.shapes))
         shader_program.vertex_list_indexed(len(vertice)//3, GL_TRIANGLES,
                         batch = self.batch,
                         group = shape,

--- a/render.py
+++ b/render.py
@@ -35,7 +35,6 @@ class RenderWindow(pyglet.window.Window):
         self.proj_mat = None
 
         self.shapes = []
-        self.shader_program = []
         self.setup()
 
         self.animate = False
@@ -71,8 +70,13 @@ class RenderWindow(pyglet.window.Window):
             if self.animate:
                 rotate_angle = dt
                 rotate_axis = Vec3(0,0,1)
-                rotate_mat_x = Mat4.from_rotation(angle = rotate_angle, vector = rotate_axis)                
-                shape.transform_mat @= rotate_mat_x
+                rotate_mat = Mat4.from_rotation(angle = rotate_angle, vector = rotate_axis)
+                
+                shape.transform_mat @= rotate_mat
+
+                # # Example) You can control the vertices of shape.
+                # shape.indexed_vertices_list.vertices[0] += 0.5 * dt
+
             '''
             Update view and projection matrix. There exist only one view and projection matrix 
             in the program, so we just assign the same matrices for all the shapes


### PR DESCRIPTION
Exchange variables between CustomGroup & Render classes.

- [edit animation & transformation code](https://github.com/IntelligentMOtionlab/SNU_ComputerGraphics/pull/1/commits/21b85874db3b7af6bd0ad140d5d5dee971b2bbdd)
When creating a shape, declare transformation matrix instead of translation&rotation

- [move animation variables from primitives to render](https://github.com/IntelligentMOtionlab/SNU_ComputerGraphics/pull/1/commits/5710ec66a8944e4a35ee9ca8a791b410b9d15345) 
Animation variables are in Render class.

- [manage shape's shader program in the Custom group](https://github.com/IntelligentMOtionlab/SNU_ComputerGraphics/pull/1/commits/a1ffe60c84907f8ce65e71fd4db23fa0f71fe8da)
Create each shader program when a shape is initialized.
Shape also manages [IndexedVertexList](https://pyglet.readthedocs.io/en/latest/modules/graphics/vertexdomain.html#pyglet.graphics.vertexdomain.IndexedVertexList) -> can manipulate shapes' vertices.



edit animation & transformation code
- require transformation instead of translate_mat&rotation_vec when initialize a shape
- rotation_vec was related to animation component, it does not have to be set in the initialization